### PR TITLE
fix(get-svg): catch SVGs without props

### DIFF
--- a/lua/nvim-preview-svg/init.lua
+++ b/lua/nvim-preview-svg/init.lua
@@ -6,7 +6,7 @@ local buffer_to_string = function()
 end
 
 local get_svg = function(content)
-  local svg_match = content:match "<svg .*>.*</svg>"
+  local svg_match = content:match "<svg.*>.*</svg>"
   svg_match = svg_match:gsub("none", "black")
   return svg_match
 end


### PR DESCRIPTION
# Feature, bug or refactor?
Bug

# Why?
The regex wasn't matching SVGs without props

# Context
Now regex matches all the cases
