### PR TITLE
feat(get-svg): handle no svg matched error

### DIFF
--- a/lua/nvim-preview-svg/init.lua
+++ b/lua/nvim-preview-svg/init.lua
@@ -7,7 +7,13 @@ end
 
 local get_svg = function(content)
   local svg_match = content:match "<svg.*>.*</svg>"
-  svg_match = svg_match:gsub("none", "black")
+
+  if svg_match then
+    svg_match = svg_match:gsub("none", "black")
+  else
+    error("No svg tag in this file")
+  end
+
   return svg_match
 end
 


### PR DESCRIPTION
# Feature, bug or refactor?
Feature

# Why?
There was no explanation when the plugin failed bc of non existing svg tags in the file

# Context
Now it checks if the regex matched something, otherwise, it raises an error
